### PR TITLE
Resolve conflicting anchor tags

### DIFF
--- a/about.md
+++ b/about.md
@@ -19,7 +19,7 @@ subcollection: fortigate-10g
 {:download: .download}
 
 # About Fortigate Security Appliance 10Gbps
-{: #getting-started-with-fortigate-security-appliance-10gbps}
+{: #about-fortigate-security-appliance-10gbps}
 
 The Fortigate Security Appliance (FSA) 10Gbps is a single tenant (dedicated), high throughput (10Gbps) hardware firewall with next generation features, such as AntiVirus (AV), Next Generation Firewall (NGFW), and Web filtering.
 


### PR DESCRIPTION
Looking at this content, the about page cannot be accessed because the anchor tag for the about page is the same as the anchor for the getting started page. They are both `{: #getting-started-with-fortigate-security-appliance-10gbps}`

Suggest changing the about page tag to `{: #about-fortigate-security-appliance-10gbps}`