### PR TITLE
Update connect-details.md

### DIFF
--- a/connect-details.md
+++ b/connect-details.md
@@ -23,15 +23,7 @@ subcollection: fortigate-10g
 # Available Data Centers
 {: #available-data-centers}
 
-IBM© offers many global data centers to connect your IBM Cloud deployment of the Fortigate Security Appliance (FSA). Connections are offered at the following speeds:
-
-* 50 mbps
-* 100 mbps
-* 200 mbps
-* 1 Gbps
-* 2 Gbps
-* 5 Gbps
-
+IBM© offers many global data centers to connect your IBM Cloud deployment of the Fortigate Security Appliance (FSA).
 Each IBM Cloud data center is connected to the IBM global private network — making data transfers faster and more efficient everywhere.
 
 The available FSA data centers and their locations are:


### PR DESCRIPTION
@jbmitch @ibm-cos-help 

Removing: Connections are offered at the following speeds:

* 50 mbps
* 100 mbps
* 200 mbps
* 1 Gbps
* 2 Gbps
* 5 Gbps


This is copied from the DirectLink Cloud Docs page and is not relevant to FSA offering. I'm not sure how/why/when this information ended up on here but it's not correct.